### PR TITLE
Replace custom_gather_gltf_hook with gather_gltf_hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Compatible Blender version
 
-&gt;= 2.91
+&gt;= 2.93.2
 
 ## How to install
 


### PR DESCRIPTION
We can remove custom hook for export with Blender 2.93.2. See https://github.com/KhronosGroup/glTF-Blender-IO/issues/1009