### PR TITLE
Update hook name to match current glTF-Blender-IO

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -226,7 +226,7 @@ class glTF2ExportUserExtension:
                 required=False
             )
 
-    def gather_gltf_hook(self, gltf2_object, export_settings):
+    def gather_gltf_extensions_hook(self, gltf2_object, export_settings):
         meshes = gltf2_object.meshes
 
         # Get all the variant names from all the meshes


### PR DESCRIPTION
Apparently, the hook rename happened in `glTF-Blender-IO` for Blender >= 3.1, so this patch fixes that. Not quite sure how to implement this to be compatible with lower Blender versions.

Fixes #15